### PR TITLE
Add eat method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ install();
 
 ## docs
 
+`Array.prototype.eat` - returns an empty array
+
 `Array.prototype.floppy` - removes the last three items of the array and returns the removed items
 
 `Array.prototype.fry` - adds 325 to every item in the array and returns itself

--- a/src/__tests__/eat.test.ts
+++ b/src/__tests__/eat.test.ts
@@ -1,0 +1,17 @@
+import install from "../index";
+
+install();
+
+describe("eat", () => {
+  test("installs on the array prototype", () => {
+    expect(Array.prototype.eat).toBeDefined();
+  });
+
+  test("works on an array", () => {
+    expect([1, 2, 3, 4, 5].eat()).toEqual([]);
+  });
+
+  test("works on an empty array", () => {
+    expect([].eat()).toEqual([]);
+  });
+});

--- a/src/eat.ts
+++ b/src/eat.ts
@@ -1,3 +1,4 @@
 export default function eat(this: any[]) {
-  return this.reduce(acc => acc, []);
+  this.splice(0, this.length);
+  return this;
 }

--- a/src/eat.ts
+++ b/src/eat.ts
@@ -1,3 +1,3 @@
-export default function floppy(this: any[]) {
+export default function eat(this: any[]) {
   return this.reduce(acc => acc, []);
 }

--- a/src/eat.ts
+++ b/src/eat.ts
@@ -1,0 +1,3 @@
+export default function floppy(this: any[]) {
+  return this.reduce(acc => acc, []);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import eat from "./eat";
 import floppy from "./floppy";
 import fry from "./fry";
 import ginormous from "./ginormous";
@@ -16,6 +17,7 @@ import tickle from "./tickle";
 
 declare global {
   interface Array<T> {
+    eat(): T[];
     fry(): number[];
     squirt(): T[];
     lubricant(length: number): T[];
@@ -39,6 +41,7 @@ declare global {
 
 export default function installLolDash() {
   Object.defineProperties(Array.prototype, {
+    eat: { value: eat },
     fry: { value: fry },
     squirt: { value: squirt },
     lubricant: { value: lubricant },


### PR DESCRIPTION
I'm so excited to contribute to this serious javascripts effort.

The vision: **you can have your pancake and eat it too**

Usage:
```javascript
ingredients.pancake().eat()
```

Seriously sorry for being so serious.