### PR TITLE
Remove link to loldash.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 very serious javascripts
 
-play with it here: [www.loldash.com](http://www.loldash.com/)
-
 ## wait what?
 
 [See here](https://twitter.com/sarah_edo/status/971761942556762112).


### PR DESCRIPTION
Unfortunately, some company has decided to take the domain lodash out from under this project. Best to remove the link until/unless a new loldash site is created.